### PR TITLE
Added support for cs3 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@ DartConfiguration.tcl
 doc/Doxyfile
 install_manifest.txt
 
-#buid folder
+#build folder
 build
-

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ DartConfiguration.tcl
 doc/Doxyfile
 install_manifest.txt
 
+#buid folder
+build
+

--- a/doc/examples/Makefile
+++ b/doc/examples/Makefile
@@ -2,7 +2,7 @@
 
 all_examples:=$(shell find -iname "*.c")
 
-CFLAGS:=$(shell pkg-config --libs --cflags gfal2) $(shell pkg-config --libs --cflags gfal_transfer)
+CFLAGS:=$(shell pkg-config --libs --cflags gfal2) $(shell pkg-config --libs --cflags gfal_transfer) -g
 OBJS=$(all_examples:%.c=%)
 
 all: $(OBJS)

--- a/doc/examples/gfal_copy.c
+++ b/doc/examples/gfal_copy.c
@@ -54,16 +54,12 @@ static void my_monitor_callback(gfalt_transfer_status_t h, const char* src,
 
 int main(int argc, char** argv)
 {
-    printf("Main");
     if (argc < 3) {
         fprintf(stderr, "Missing source and/or destination parameter");
         abort();
     }
     const char* source = argv[1];
     const char* destination = argv[2];
-
-    setenv("SRC_URL", source, 1);
-    setenv("DST_URL", destination, 1);
 
     // Errors will be put here
     GError* error = NULL;
@@ -79,7 +75,7 @@ int main(int argc, char** argv)
 
     gfalt_set_timeout(params, 60, &error);                  // 60 seconds timeout
     gfalt_set_dst_spacetoken(params, "TOKEN", &error);      // Destination space token, support depends on the plugin (SRM, XROOTD do support this)
-    gfalt_set_replace_existing_file(params, TRUE, &error); // Just in case, do not overwrite
+    gfalt_set_replace_existing_file(params, FALSE, &error); // Just in case, do not overwrite
     gfalt_set_checksum(params, GFALT_CHECKSUM_NONE, NULL, NULL, NULL); // No checksum
     gfalt_set_create_parent_dir(params, TRUE, &error);      // Create the parent directory if needed
     // Callbacks
@@ -93,6 +89,5 @@ int main(int argc, char** argv)
     // Release memory
     gfalt_params_handle_delete(params, &error);
     gfal2_context_free(context);
-    printf("Transfer Compelete :) \n");
     return 0;
 }

--- a/doc/examples/gfal_copy.c
+++ b/doc/examples/gfal_copy.c
@@ -47,20 +47,23 @@ static void my_monitor_callback(gfalt_transfer_status_t h, const char* src,
         size_t inst = gfalt_copy_get_instant_baudrate(h, NULL);
         size_t trans = gfalt_copy_get_bytes_transfered(h, NULL);
         time_t elapsed = gfalt_copy_get_elapsed_time(h, NULL);
-
-        printf("%d bytes/second average (%d instant). Transferred %d, elapsed %d seconds", avg, inst, trans, elapsed);
+        printf("%d bytes/second average (%d instant). Transferred %d, elapsed %d seconds \n", avg, inst, trans, elapsed);
     }
 }
 
 
 int main(int argc, char** argv)
 {
+    printf("Main");
     if (argc < 3) {
         fprintf(stderr, "Missing source and/or destination parameter");
         abort();
     }
     const char* source = argv[1];
     const char* destination = argv[2];
+
+    setenv("SRC_URL", source, 1);
+    setenv("DST_URL", destination, 1);
 
     // Errors will be put here
     GError* error = NULL;
@@ -76,10 +79,9 @@ int main(int argc, char** argv)
 
     gfalt_set_timeout(params, 60, &error);                  // 60 seconds timeout
     gfalt_set_dst_spacetoken(params, "TOKEN", &error);      // Destination space token, support depends on the plugin (SRM, XROOTD do support this)
-    gfalt_set_replace_existing_file(params, FALSE, &error); // Just in case, do not overwrite
+    gfalt_set_replace_existing_file(params, TRUE, &error); // Just in case, do not overwrite
     gfalt_set_checksum(params, GFALT_CHECKSUM_NONE, NULL, NULL, NULL); // No checksum
     gfalt_set_create_parent_dir(params, TRUE, &error);      // Create the parent directory if needed
-
     // Callbacks
     gfalt_add_event_callback(params, my_event_callback, NULL, NULL, &error);     // Called when some event is triggered
     gfalt_add_monitor_callback(params, my_monitor_callback, NULL, NULL, &error); // Performance monitor
@@ -91,5 +93,6 @@ int main(int argc, char** argv)
     // Release memory
     gfalt_params_handle_delete(params, &error);
     gfal2_context_free(context);
+    printf("Transfer Compelete :) \n");
     return 0;
 }

--- a/src/plugins/http/gfal_http_copy.cpp
+++ b/src/plugins/http/gfal_http_copy.cpp
@@ -136,7 +136,7 @@ static void set_copy_mode_from_urls(gfal2_context_t context, const char * src_ur
 
 static bool is_http_scheme(const char* url)
 {
-    const char *schemes[] = {"http:", "https:", "dav:", "davs:", "s3:", "s3s:", "gcloud:", "gclouds:", "swift:", "swifts:", "cs3:", NULL};
+    const char *schemes[] = {"http:", "https:", "dav:", "davs:", "s3:", "s3s:", "gcloud:", "gclouds:", "swift:", "swifts:", "cs3:", "cs3s:", NULL};
     const char *colon = strchr(url, ':');
     if (!colon)
         return false;
@@ -528,7 +528,7 @@ static int gfal_http_streamed_copy(gfal2_context_t context,
     	req_params.setProtocol(Davix::RequestProtocol::Gcloud);
     else if (dst_uri.getProtocol() == "swift" || dst_uri.getProtocol() == "swifts")
         req_params.setProtocol(Davix::RequestProtocol::Swift);
-    else if (dst_uri.getProtocol() == "cs3")
+    else if (dst_uri.getProtocol() == "cs3" || dst_uri.getProtocol() == "cs3s")
         req_params.setProtocol(Davix::RequestProtocol::CS3);
 
     Davix::DavFile dest(davix->context,req_params, dst_uri );

--- a/src/plugins/http/gfal_http_copy.cpp
+++ b/src/plugins/http/gfal_http_copy.cpp
@@ -136,7 +136,7 @@ static void set_copy_mode_from_urls(gfal2_context_t context, const char * src_ur
 
 static bool is_http_scheme(const char* url)
 {
-    const char *schemes[] = {"http:", "https:", "dav:", "davs:", "s3:", "s3s:", "gcloud:", "gclouds:", "swift:", "swifts:", NULL};
+    const char *schemes[] = {"http:", "https:", "dav:", "davs:", "s3:", "s3s:", "gcloud:", "gclouds:", "swift:", "swifts:", "cs3:", NULL};
     const char *colon = strchr(url, ':');
     if (!colon)
         return false;
@@ -331,7 +331,7 @@ static std::string get_canonical_uri(const std::string& original)
     std::string scheme;
     char last_scheme;
 
-    if ((original.compare(0, 2, "s3") == 0)  || (original.compare(0, 6, "gcloud") == 0 ) || original.compare(0, 5, "swift") == 0) {
+    if ((original.compare(0, 2, "s3") == 0)  || (original.compare(0, 6, "gcloud") == 0 ) || original.compare(0, 5, "swift") == 0 || original.compare(0, 3, "cs3") == 0) {
         return original;
     }
 
@@ -528,6 +528,8 @@ static int gfal_http_streamed_copy(gfal2_context_t context,
     	req_params.setProtocol(Davix::RequestProtocol::Gcloud);
     else if (dst_uri.getProtocol() == "swift" || dst_uri.getProtocol() == "swifts")
         req_params.setProtocol(Davix::RequestProtocol::Swift);
+    else if (dst_uri.getProtocol() == "cs3")
+        req_params.setProtocol(Davix::RequestProtocol::CS3);
 
     Davix::DavFile dest(davix->context,req_params, dst_uri );
 

--- a/src/plugins/http/gfal_http_plugin.cpp
+++ b/src/plugins/http/gfal_http_plugin.cpp
@@ -28,6 +28,7 @@
 #include <davix.hpp>
 #include <errno.h>
 #include <davix/utils/davix_gcloud_utils.hpp>
+#include <davix/utils/davix_cs3_utils.hpp>
 #include <exceptions/gfalcoreexception.hpp>
 
 using namespace Davix;
@@ -408,6 +409,14 @@ void GfalHttpPluginData::get_gcloud_credentials(Davix::RequestParams& params, co
     g_free(gcloud_json_string);
 }
 
+void GfalHttpPluginData::get_reva_credentials(Davix::RequestParams &params, const Davix::Uri &uri, bool token_write_access)
+{   
+    reva::CredentialProvider provider;
+    reva::Credentials creds = params.getRevaCredentials();
+    provider.updateCredentials(creds, uri.getString(), token_write_access);
+    params.setRevaCredentials(creds);
+}
+
 void GfalHttpPluginData::get_credentials(Davix::RequestParams& params, const Davix::Uri& uri,
                                          bool token_write_access, unsigned token_validity,
                                          bool secondary_endpoint)
@@ -424,6 +433,8 @@ void GfalHttpPluginData::get_credentials(Davix::RequestParams& params, const Dav
         get_gcloud_credentials(params, uri);
     } else if (uri.getProtocol().compare(0, 5, "swift") == 0) {
         get_swift_params(params, uri);
+    }else if (uri.getProtocol().compare(0, 3, "cs3") == 0) {
+        get_reva_credentials(params, uri, token_write_access);
     }// Use bearer token (other authentication mechanism should be disabled)
       // Not the case for the moment, as certificates are still used (but should be unset in the future)
     else if (!get_token(params, uri, token_write_access, token_validity,
@@ -447,7 +458,9 @@ void GfalHttpPluginData::get_params_internal(Davix::RequestParams& params, const
         params.setProtocol(Davix::RequestProtocol::Gcloud);
     } else if (uri.getProtocol().compare(0, 5, "swift") == 0) {
         params.setProtocol(Davix::RequestProtocol::Swift);
-    } else {
+    } else if (uri.getProtocol().compare(0, 3, "cs3") == 0) {
+        params.setProtocol(Davix::RequestProtocol::CS3);
+    }else {
         params.setProtocol(Davix::RequestProtocol::Auto);
     }
 
@@ -662,7 +675,8 @@ static gboolean gfal_http_check_url(plugin_handle plugin_data, const char* url,
                  strncmp("gcloud:", url, 7) == 0 || strncmp("gclouds:", url, 8) == 0 ||
                  strncmp("swift:", url, 6) == 0 || strncmp("swifts:", url, 7) == 0 ||
                  strncmp("http+3rd:", url, 9) == 0 || strncmp("https+3rd:", url, 10) == 0 ||
-                 strncmp("dav+3rd:", url, 8) == 0 || strncmp("davs+3rd:", url, 9) == 0);
+                 strncmp("dav+3rd:", url, 8) == 0 || strncmp("davs+3rd:", url, 9) == 0 ||
+                 strncmp("cs3:", url, 4) == 0);
       default:
         return false;
     }

--- a/src/plugins/http/gfal_http_plugin.cpp
+++ b/src/plugins/http/gfal_http_plugin.cpp
@@ -411,6 +411,11 @@ void GfalHttpPluginData::get_gcloud_credentials(Davix::RequestParams& params, co
 
 void GfalHttpPluginData::get_reva_credentials(Davix::RequestParams &params, const Davix::Uri &uri, bool token_write_access)
 {   
+    // The authentication with Reva is yet to be properly designed.
+    // Nevertheless, there is a need to associate tokens to URLs given that a token issued for a destination must have write rights,
+    // whereas right now GFAL issues a `stat()` == `HEAD` request also to the destination without requiring write rights.
+    // To be further developed.
+
     reva::CredentialProvider provider;
     reva::Credentials creds = params.getRevaCredentials();
     provider.updateCredentials(creds, uri.getString(), token_write_access);
@@ -676,7 +681,7 @@ static gboolean gfal_http_check_url(plugin_handle plugin_data, const char* url,
                  strncmp("swift:", url, 6) == 0 || strncmp("swifts:", url, 7) == 0 ||
                  strncmp("http+3rd:", url, 9) == 0 || strncmp("https+3rd:", url, 10) == 0 ||
                  strncmp("dav+3rd:", url, 8) == 0 || strncmp("davs+3rd:", url, 9) == 0 ||
-                 strncmp("cs3:", url, 4) == 0);
+                 strncmp("cs3:", url, 4) == 0 || strncmp("cs3s:", url, 5) == 0);
       default:
         return false;
     }

--- a/src/plugins/http/gfal_http_plugin.h
+++ b/src/plugins/http/gfal_http_plugin.h
@@ -96,6 +96,9 @@ private:
     // Obtain GCloud endpoint credentials
     void get_gcloud_credentials(Davix::RequestParams& params, const Davix::Uri& uri);
 
+    // Obtain Reva endpoint credentials
+    void get_reva_credentials(Davix::RequestParams &params, const Davix::Uri &uri, bool token_write_access);
+    
     // Obtain certificate credentials
     void get_certificate(Davix::RequestParams& params, const Davix::Uri& uri);
 

--- a/src/plugins/http/gfal_http_plugin_io.cpp
+++ b/src/plugins/http/gfal_http_plugin_io.cpp
@@ -52,7 +52,7 @@ gfal_file_handle gfal_http_fopen(plugin_handle plugin_data, const char* url, int
     else if (strncmp("swift:", url, 6) == 0 || strncmp("swifts:", url, 7) == 0) {
         fd->req_params.setProtocol(Davix::RequestProtocol::Swift);
     }
-    else if (strncmp("cs3:", url, 4) == 0) {
+    else if (strncmp("cs3:", url, 4) == 0 || strncmp("cs3s:", url, 5) == 0) {
         fd->req_params.setProtocol(Davix::RequestProtocol::CS3);
     }
 

--- a/src/plugins/http/gfal_http_plugin_io.cpp
+++ b/src/plugins/http/gfal_http_plugin_io.cpp
@@ -52,6 +52,10 @@ gfal_file_handle gfal_http_fopen(plugin_handle plugin_data, const char* url, int
     else if (strncmp("swift:", url, 6) == 0 || strncmp("swifts:", url, 7) == 0) {
         fd->req_params.setProtocol(Davix::RequestProtocol::Swift);
     }
+    else if (strncmp("cs3:", url, 4) == 0) {
+        fd->req_params.setProtocol(Davix::RequestProtocol::CS3);
+    }
+
     fd->davix_fd = davix->posix.open(&fd->req_params, stripped_url, flag, &daverr);
 
     if (fd->davix_fd == NULL) {


### PR DESCRIPTION
CS3APIs are a set of interfaces used to communicate between various entities within science mesh. 

This PR aims to add compatibility within the gfal multiplexer to perform third party copies with science mesh endpoints running the interoperability platform reva. 

We extend the `http-plugin` with the ability to fetch and initialise `Davix::RequestParams` with `Davix::RequestProtocol::CS3` for transfer endpoints with `cs3:` prefix.
Relevant interfaces were added to `libdavix` in PR https://github.com/cern-fts/davix/pull/72


