### PR TITLE
[CMake] Explicitly state the dependency relation of the XRootD plugin and the uuid

### DIFF
--- a/src/plugins/xrootd/CMakeLists.txt
+++ b/src/plugins/xrootd/CMakeLists.txt
@@ -4,7 +4,11 @@ if (PLUGIN_XROOTD)
 
     find_package(XROOTD REQUIRED)
 
-    include_directories(${XROOTD_INCLUDE_DIR} ${JSONC_INCLUDE_DIRS})
+    include_directories(
+        ${XROOTD_INCLUDE_DIR}
+        ${JSONC_INCLUDE_DIRS}
+        ${UUID_INCLUDE_DIRS}
+    )
 
     file (GLOB src_xrootd "*.cpp")
 
@@ -16,12 +20,14 @@ if (PLUGIN_XROOTD)
         gfal2_transfer
         ${XROOTD_LIBRARIES}
         ${JSONC_LIBRARIES}
+        ${UUID_LIBRARIES}
     )
     target_link_libraries(plugin_xrootd_static
         ${GFAL2_PKG_LIBRARIES}
         gfal2_transfer
         ${XROOTD_LIBRARIES}
         ${JSONC_LIBRARIES}
+        ${UUID_LIBRARIES}
     )
     
     set_target_properties(plugin_xrootd PROPERTIES


### PR DESCRIPTION
When building from source and enable the XRootD plugin only, one can get from the CMake configuration failure that XRootD is required. However, it doesn't inform the users the need of the `uuid` library untill the compilation error occurs.

This situation can be avoided with this patch applied.