### PR TITLE
Add support for BEARER_TOKEN_FILE.

### DIFF
--- a/src/core/common/gfal_cred_mapping.h
+++ b/src/core/common/gfal_cred_mapping.h
@@ -40,6 +40,12 @@ extern "C"
 #define GFAL_CRED_PASSWD "PASSWORD"
 /// Bearer token-type credential
 #define GFAL_CRED_BEARER "BEARER"
+/// Bearer token-type credential located in a file.
+//  This is different from the BEARER type as the plugins
+//  should never cache the contents of the BEARER_FILE and
+//  reloaded it each time it is needed.  This way, credentials
+//  can be updated outside the process.
+#define GFAL_CRED_BEARER_FILE "BEARER_FILE"
 
 /**
  * Stores a credential value together with its type
@@ -130,6 +136,17 @@ int gfal2_cred_copy(gfal2_context_t dest, const gfal2_context_t src, GError **er
  * @param user_data     To be passed to the callback
  */
 void gfal2_cred_foreach(gfal2_context_t handle, gfal_cred_func_t callback, void *user_data);
+
+/**
+ * Given a filename, read it and return any token that is present.
+ * On success, if value is non-null it will be allocated and set to the
+ * value of the found token.
+ *
+ * @param token_file    The file to search for tokens.
+ * @param value         Output; value of found token.
+ * @return              0 on success, -1 on error.
+ */
+int gfal2_cred_get_token_from_file(const char *token_file, char **value);
 
 #ifdef __cplusplus
 }

--- a/src/plugins/http/gfal_http_plugin.cpp
+++ b/src/plugins/http/gfal_http_plugin.cpp
@@ -150,6 +150,11 @@ char* GfalHttpPluginData::find_se_token(const Davix::Uri& uri, const OP& operati
 
         if (strcmp(cred->type, GFAL_CRED_BEARER) == 0) {
             cred_list->emplace_back(url_prefix, cred->value);
+        } else if (cred->value && strcmp(cred->type, GFAL_CRED_BEARER_FILE) == 0) {
+            char *token_contents;
+            if (0 == gfal2_cred_get_token_from_file(cred->value, &token_contents)) {
+                cred_list->emplace_back(url_prefix, token_contents);
+            }
         }
     };
 
@@ -182,6 +187,12 @@ char* GfalHttpPluginData::find_se_token(const Davix::Uri& uri, const OP& operati
     GError* error = NULL;
     char* token = gfal2_cred_get(handle, GFAL_CRED_BEARER, uri.getHost().c_str(), NULL, &error);
     g_clear_error(&error);
+
+    if (!token) {
+        char *token_file = gfal2_cred_get(handle, GFAL_CRED_BEARER_FILE, uri.getHost().c_str(), NULL, &error);
+        g_clear_error(&error);
+        if (token_file) gfal2_cred_get_token_from_file(token_file, &token);
+    }
 
     return token;
 }


### PR DESCRIPTION
The WLCG bearer token discovery protocol includes the `BEARER_TOKEN_FILE` environment variable which indicates a filename the token should be loaded from.  This allows tokens to be updated throughout the runtime of the gfal2 library invocations.